### PR TITLE
chore: go 1.24 + update how-to share code

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,9 +18,7 @@ import (
 	"github.com/BeReal-Candidates/backend-go-test/discovery"
 )
 
-var (
-	DefaultPageSize = uint(3)
-)
+var DefaultPageSize = uint(3)
 
 func main() {
 	ctx, cf := context.WithCancel(context.Background())

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -13,13 +13,13 @@ type Service interface {
 }
 
 type service struct {
-	posts []*Post
+	posts    []*Post
 	pageSize uint
 }
 
 func NewService(pageSize uint) Service {
 	return &service{
-		posts: make([]*Post, 0, 10),
+		posts:    make([]*Post, 0, 10),
 		pageSize: pageSize,
 	}
 }

--- a/doc/HOW_TO_SHARE_MY_CODE.md
+++ b/doc/HOW_TO_SHARE_MY_CODE.md
@@ -47,7 +47,9 @@ You have to add these reviewers as collaborators to your repository:
 - maxbrlvd
 - optplx
 
-And please create a pull request for the changes that you made.
+Please create a pull request for the changes that you made. Make sure to write in the description of the PR what you want us to know about your chosen approach, any bugs you have found and fixed.
+
+Finally, don’t forget to upload your case (as a zip or GitHub link) using the second link included in the email you received about the case study.
 
 From this stage, we considerer you have finished the task!
 
@@ -55,7 +57,12 @@ From this stage, we considerer you have finished the task!
 <img src="./2.add_collaborators.png" width=600 />
 </p>
 
-## 5 - Chill & Wait
+## 5 - Code review
 
-Then it us to reach you after we review your code.
+The reviewers will review your code, and possibly leave some comments on your PR.
+So please keep an eye on it, and answer the all the questions that the reviewers might have.
+
+## 6 - Chill & Wait
+
+Then it's us to reach you after the review is done.
 Just chill!

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BeReal-Candidates/backend-go-test
 
-go 1.19
+go 1.24
 
 require google.golang.org/grpc v1.53.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,17 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jaevor/go-nanoid v1.3.0 h1:nD+iepesZS6pr3uOVf20vR9GdGgJW1HPaR46gtrxzkg=
 github.com/jaevor/go-nanoid v1.3.0/go.mod h1:SI+jFaPuddYkqkVQoNGHs81navCtH388TcrH0RqFKgY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
 golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
@@ -24,3 +28,4 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Update Go version 1.24
- Improve the how-to share code instruction